### PR TITLE
Fix validator-private-key-path to read plain hex keys instead of PEM …

### DIFF
--- a/node/src/main/scala/coop/rchain/node/Main.scala
+++ b/node/src/main/scala/coop/rchain/node/Main.scala
@@ -146,7 +146,7 @@ object Main {
         val getPrivateKey =
           maybePrivateKey
             .map(_.pure[F])
-            .orElse(maybePrivateKeyPath.map(decryptKeyFromCon[F]))
+            .orElse(maybePrivateKeyPath.map(readPlainKeyFromFile[F]))
             .sequence
         for {
           privateKey <- getPrivateKey
@@ -224,14 +224,6 @@ object Main {
       case _                                  => Help
     }
 
-  private def decryptKeyFromCon[F[_]: Sync: ConsoleIO](
-      encryptedPrivateKeyPath: Path
-  ): F[PrivateKey] =
-    for {
-      password   <- getValidatorPassword
-      privateKey <- Secp256k1.parsePemFile[F](encryptedPrivateKeyPath, password)
-    } yield privateKey
-
   private def generateKey[F[_]: Sync: ConsoleIO](path: Path): F[Unit] =
     for {
       password       <- ConsoleIO[F].readPassword("Enter password for keyfile: ")
@@ -272,23 +264,39 @@ object Main {
           }
     } yield ()
 
-  private val RNodeValidatorPasswordEnvVar = "RNODE_VALIDATOR_PASSWORD"
-
   /**
-    * Reads validator password from RNODE_VALIDATOR_PASSWORD env variable, if not set - asks for console
+    * Reads a plain base16-encoded private key from a file.
+    * The file should contain a hex string (with optional whitespace).
+    * @param keyPath Path to the key file
+    * @return Private key decoded from the file
     */
-  def getValidatorPassword[F[_]: Sync: ConsoleIO]: F[String] =
-    sys.env.get(RNodeValidatorPasswordEnvVar) match {
-      case Some(password) =>
-        if (password.length > 0) password.pure[F] else requestForPassword[F]
-      case None => requestForPassword[F]
-    }
-
-  def requestForPassword[F[_]: ConsoleIO]: F[String] =
-    ConsoleIO[F].readPassword(
-      "Variable RNODE_VALIDATOR_PASSWORD is not set, please enter password for keyfile. \n" +
-        "Password for keyfile: "
-    )
+  private def readPlainKeyFromFile[F[_]: Sync](keyPath: Path): F[PrivateKey] =
+    for {
+      fileContent <- Sync[F].delay(
+                      scala.io.Source
+                        .fromFile(keyPath.toFile)
+                        .mkString
+                        .replaceAll("\\s", "") // Remove all whitespace including newlines
+                    )
+      _ <- if (fileContent.isEmpty)
+            Sync[F].raiseError[Unit](
+              new Exception(
+                s"Invalid private key file format at $keyPath. " +
+                  "File is empty or contains only whitespace."
+              )
+            )
+          else ().pure[F]
+      privateKeyBytes <- Base16
+                          .decode(fileContent)
+                          .fold(
+                            Sync[F].raiseError[Array[Byte]](
+                              new Exception(
+                                s"Invalid private key file format at $keyPath. " +
+                                  "Expected base16-encoded (hex) private key."
+                              )
+                            )
+                          )(_.pure[F])
+    } yield PrivateKey(privateKeyBytes)
 
   /**
     * Loads validator key from file into configuration.
@@ -300,7 +308,7 @@ object Main {
     conf.casper.validatorPrivateKeyPath match {
       case Some(privateKeyPath) =>
         for {
-          privateKeyBase16 <- decryptKeyFromCon[F](privateKeyPath)
+          privateKeyBase16 <- readPlainKeyFromFile[F](privateKeyPath)
                                .map(sk => Base16.encode(sk.bytes))
         } yield conf.copy(casper = conf.casper.copy(validatorPrivateKey = Some(privateKeyBase16)))
       case _ => conf.pure[F]

--- a/node/src/test/scala/coop/rchain/node/ReadPlainKeyFromFileSpec.scala
+++ b/node/src/test/scala/coop/rchain/node/ReadPlainKeyFromFileSpec.scala
@@ -1,0 +1,134 @@
+package coop.rchain.node
+
+import cats.effect.Sync
+import cats.effect.laws.util.TestContext
+import coop.rchain.crypto.PrivateKey
+import coop.rchain.shared.Base16
+import monix.eval.Task
+import monix.execution.Scheduler
+import org.scalatest.{BeforeAndAfterAll, FunSuite, Matchers}
+
+import java.nio.file.{Files, Path, Paths}
+
+class ReadPlainKeyFromFileSpec extends FunSuite with Matchers with BeforeAndAfterAll {
+  implicit val scheduler: Scheduler = Scheduler.Implicits.global
+
+  // Sample private key for testing (64 hex characters = 32 bytes)
+  val validPrivateKeyHex   = "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef"
+  val validPrivateKeyBytes = Base16.decode(validPrivateKeyHex).get
+
+  var tempDir: Path = _
+
+  override def beforeAll(): Unit =
+    tempDir = Files.createTempDirectory("rnode-test-keys")
+
+  override def afterAll(): Unit = {
+    // Clean up temp directory
+    import scala.collection.JavaConverters._
+    Files
+      .walk(tempDir)
+      .iterator()
+      .asScala
+      .toSeq
+      .reverse
+      .foreach(Files.deleteIfExists)
+  }
+
+  // Helper to create a test key file
+  def createKeyFile(content: String, filename: String = "test.key"): Path = {
+    val keyFile = tempDir.resolve(filename)
+    Files.write(keyFile, content.getBytes)
+    keyFile
+  }
+
+  // Access to the private method via reflection
+  def readPlainKeyFromFile[F[_]: Sync](keyPath: Path): F[PrivateKey] = {
+    val mainClass  = Class.forName("coop.rchain.node.Main$")
+    val mainObject = mainClass.getField("MODULE$").get(null)
+    val method = mainClass.getDeclaredMethod(
+      "readPlainKeyFromFile",
+      classOf[Path],
+      classOf[Sync[F]]
+    )
+    method.setAccessible(true)
+    method.invoke(mainObject, keyPath, implicitly[Sync[F]]).asInstanceOf[F[PrivateKey]]
+  }
+
+  test("readPlainKeyFromFile should read a valid hex private key") {
+    val keyFile = createKeyFile(validPrivateKeyHex)
+
+    val result = readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+
+    result.bytes shouldEqual validPrivateKeyBytes
+  }
+
+  test("readPlainKeyFromFile should handle hex key with whitespace") {
+    val keyWithWhitespace = s"  \n  $validPrivateKeyHex  \n  "
+    val keyFile           = createKeyFile(keyWithWhitespace)
+
+    val result = readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+
+    result.bytes shouldEqual validPrivateKeyBytes
+  }
+
+  test("readPlainKeyFromFile should handle hex key with newlines") {
+    val keyWithNewlines = validPrivateKeyHex.grouped(16).mkString("\n")
+    val keyFile         = createKeyFile(keyWithNewlines)
+
+    val result = readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+
+    result.bytes shouldEqual validPrivateKeyBytes
+  }
+
+  test("readPlainKeyFromFile should fail on invalid hex") {
+    val invalidHex = "not a hex string!!!"
+    val keyFile    = createKeyFile(invalidHex)
+
+    val exception = intercept[Exception] {
+      readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+    }
+
+    exception.getMessage should include("Invalid private key file format")
+    exception.getMessage should include("Expected base16-encoded (hex) private key")
+  }
+
+  test("readPlainKeyFromFile should fail on non-existent file") {
+    val nonExistentFile = tempDir.resolve("does-not-exist.key")
+
+    val exception = intercept[Exception] {
+      readPlainKeyFromFile[Task](nonExistentFile).runSyncUnsafe()
+    }
+
+    // Should be a file not found exception
+    exception.getMessage should include("does-not-exist.key")
+  }
+
+  test("readPlainKeyFromFile should fail on empty file") {
+    val emptyFile = createKeyFile("")
+
+    val exception = intercept[Exception] {
+      readPlainKeyFromFile[Task](emptyFile).runSyncUnsafe()
+    }
+
+    exception.getMessage should include("Invalid private key file format")
+  }
+
+  test("readPlainKeyFromFile should handle uppercase hex") {
+    val uppercaseHex = validPrivateKeyHex.toUpperCase
+    val keyFile      = createKeyFile(uppercaseHex)
+
+    val result = readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+
+    result.bytes shouldEqual validPrivateKeyBytes
+  }
+
+  test("readPlainKeyFromFile should handle mixed case hex") {
+    val mixedCaseHex  = "1234567890AbCdEf1234567890aBcDeF1234567890abCDEF1234567890ABCDEF"
+    val expectedBytes = Base16.decode(mixedCaseHex).get
+    val keyFile       = createKeyFile(mixedCaseHex)
+
+    val result = readPlainKeyFromFile[Task](keyFile).runSyncUnsafe()
+
+    result.bytes shouldEqual expectedBytes
+  }
+}


### PR DESCRIPTION
Fixes #198.

The validator-private-key-path configuration option was incorrectly trying to parse key files as encrypted PEM files, which caused a NullPointerException when the file didn't contain a PEM-formatted key.

## Overview

This fix makes validator-private-key-path work consistently with validator-private-key - both now accept plain base16-encoded (hex) private keys. The key file format is flexible, allowing whitespace and newlines for readability.

Changes:
- Created readPlainKeyFromFile() to read hex-encoded keys from files
- Updated loadPrivateKeyFromFile() to use the new function
- Updated Deploy command handler for consistent behavior
- Removed obsolete PEM decryption functions (decryptKeyFromCon, getValidatorPassword, requestForPassword)
- Added comprehensive test suite with 8 passing tests covering valid inputs, error cases, and various formatting options
